### PR TITLE
Add pipe escaping support for cell values

### DIFF
--- a/src/formatters/tableCellFormatter.ts
+++ b/src/formatters/tableCellFormatter.ts
@@ -8,5 +8,5 @@ export function format(tableCell: TableCell): string {
   if (!tableCell) {
     throw new Error("TableCell must be set!");
   }
-  return tableCell.value;
+  return tableCell.value.replace(/\|/g, '\\|');
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -426,6 +426,20 @@ describe("gherkin-formatter", () => {
                 // @ts-ignore
                 expect(() => formatTableCell()).toThrow("TableCell must be set!");
             });
+            test("should handle pipes", () => {
+                const rows = [
+                    new TableRow([
+                        new TableCell("a"),
+                        new TableCell("b"),
+                    ]),
+                    new TableRow([
+                        new TableCell("a | a | a"),
+                        new TableCell("bbbbb"),
+                    ]),
+                ];
+                const result = formatTableRows(rows);
+                expect(splitToLines(result)).toEqual(["| a           | b     |", "| a \\| a \\| a | bbbbb |"]);
+            });
         });
 
         describe("tableRowsFormatter", () => {

--- a/tests/testData/base.feature
+++ b/tests/testData/base.feature
@@ -29,9 +29,9 @@ Feature: Hello world
         | val2 |
         | val3 |
       And this is a when step with data table too
-        | col1 | col2 |
-        | val1 | val2 |
-        | val3 | val4 |
+        | col1 | col2                 |
+        | val1 | val2                 |
+        | val3 | val4 \| val5 \| val6 |
       And this is a when step with doc string
         """
         Hello world
@@ -61,9 +61,9 @@ Feature: Hello world
 
       @tagE1
       Examples: First examples
-        | key    | key2   |
-        | value1 | value2 |
-        | value3 | value4 |
+        | key    | key2                        |
+        | value1 | value2                      |
+        | value3 | value4 \| value5 \| value 6 |
 
       Examples: Second examples
         | key    |


### PR DESCRIPTION
If you put the pipe into cell value, read the feature, and write it back, the escaped pipe will become unescaped, breaking the syntax.